### PR TITLE
Gamma Correction and Brightness Scaling improvements for Uncharted: L…

### DIFF
--- a/src/games/unchartedlotc/addon.cpp
+++ b/src/games/unchartedlotc/addon.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Musa Haji
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <embed/0x545B3706.h>  // Linearization + BT.2020 + PQ Encoding
+
+#include <include/reshade.hpp>
+#include "../../mods/shader.hpp"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    CustomShaderEntry(0x545B3706),  // Linearization + BT.2020 + PQ Encoding
+};
+
+}  // namespace
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+extern "C" __declspec(dllexport) const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) const char* DESCRIPTION = "RenoDX for Uncharted: Legacy of Thieves Collection";
+
+// NOLINTEND(readability-identifier-naming)
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      break;
+  }
+
+  renodx::mods::shader::Use(fdw_reason, custom_shaders);
+
+  return TRUE;
+}

--- a/src/games/unchartedlotc/final_0x545B3706.ps_6_0.hlsl
+++ b/src/games/unchartedlotc/final_0x545B3706.ps_6_0.hlsl
@@ -1,0 +1,37 @@
+#include "./shared.h"
+
+Texture2D<float4> g_applyHdrCodingSrcTmpBuffer : register(t0, space0);
+SamplerState g_applyHdrCodingSamplerState : register(s0, space0);
+
+cbuffer g_applyHdrCodingConstants : register(b0, space1) {
+  float4 m_params;
+};
+
+struct PSInput {
+  float4 SV_Position : SV_POSITION;
+  float2 TEXCOORD : TEXCOORD;
+};
+
+float4 main(PSInput IN)
+    : SV_Target {
+  float3 inputColor = g_applyHdrCodingSrcTmpBuffer.Sample(g_applyHdrCodingSamplerState, IN.TEXCOORD).xyz;
+
+  // Linearize with 2.2 Gamma
+  float3 linearColor = renodx::color::gamma::DecodeSafe(inputColor, 2.2);
+
+  // Use custom paper white values based on the brightness setting (m_params.x)
+  float paperWhite = m_params.x;
+  // Check brightness levels and adjust paper white accordingly
+  if (m_params.x == 220) {
+    paperWhite = 203.0f;  // Brightness level 3 (set to BT.2408 reference white)
+  } else if (m_params.x == 260) {
+    paperWhite = 250.0f;  // Brightness level 4
+  }
+
+  // Convert from BT.709 to BT.2020 PQ with paper white based on brightness slider
+  float3 bt2020Color = renodx::color::bt2020::from::BT709(linearColor);
+  float3 pqEncodedColor = renodx::color::pq::Encode(bt2020Color, paperWhite);
+
+  // Return the final PQ-encoded color with alpha set to 1.0
+  return float4(pqEncodedColor, 1.0);
+}

--- a/src/games/unchartedlotc/shared.h
+++ b/src/games/unchartedlotc/shared.h
@@ -1,0 +1,8 @@
+#ifndef SRC_UNCHARTEDLOTC_SHARED_H_
+#define SRC_UNCHARTEDLOTC_SHARED_H_
+
+#ifndef __cplusplus
+#include "../../shaders/renodx.hlsl"
+#endif
+
+#endif  // SRC_UNCHARTEDLOTC_SHARED_H_


### PR DESCRIPTION
…egacy of Thieves Collection (#62)

* unchartedlotc: initial commit, add bt.709 gamma correction

* unchartedlotc: adjust brightness slider so 3 is 203, 4 is 250

* unchartedlotc: remove all settings and relevant dependencies, clang-format

* unchartedlotc: initial commit, add bt.709 gamma correction

* unchartedlotc: adjust brightness slider so 3 is 203, 4 is 250

* unchartedlotc: remove all settings and relevant dependencies, clang-format

* unchartedlotc: update use of deprecated functions